### PR TITLE
Add unit tests for LineComment constructor

### DIFF
--- a/src/cubing/alg/units/leaves/LineComment.spec.ts
+++ b/src/cubing/alg/units/leaves/LineComment.spec.ts
@@ -1,0 +1,35 @@
+import { LineComment } from "./LineComment";
+
+describe("LineComment", () => {
+  const expectedErrorMessage = "LineComment cannot contain newline";
+
+  it("throws an error when a newline is provided in the input", () => {
+    expect(
+      () => new LineComment("This is a comment \n with a newline"),
+    ).toThrow(expectedErrorMessage);
+    expect(() => new LineComment("A newline character \r")).toThrow(
+      expectedErrorMessage,
+    );
+  });
+
+  it("does not throw an error when emojis are provided in the input", () => {
+    expect(
+      () => new LineComment("This string contains emojis 😀 😅"),
+    ).not.toThrow(expectedErrorMessage);
+  });
+
+  it("does not throw an error when text characters are provided in the input", () => {
+    expect(
+      () =>
+        new LineComment(
+          "This is just a bunch of text characters in a comment.",
+        ),
+    ).not.toThrow(expectedErrorMessage);
+  });
+
+  it("does not throw an error when special characters are provided in the input", () => {
+    expect(() => new LineComment("Th!s cont@in$ $pec!@l ch@r$")).not.toThrow(
+      expectedErrorMessage,
+    );
+  });
+});


### PR DESCRIPTION
Signed-off-by: sachinh19 <sachinhaldavanekar@gmail.com>

This PR addresses the requirements in the comments made on Issue https://github.com/cubing/cubing.js/issues/97