### PR TITLE
Documentation: Added "Drafts" folder and "Documentation Guidelines.md"

### DIFF
--- a/docs/cubing/README.md
+++ b/docs/cubing/README.md
@@ -1,4 +1,4 @@
-*NB: This information is still in draft form, and should not be relied upon to inform usage of or contribution to `cubing.js`.*
+*NB: This information is still in draft form. Do not rely on it to use or contribute to `cubing.js`.*
 
 ## Purpose of this document
 
@@ -6,8 +6,8 @@ This document serves to describe `cubing.js`'s approach to documentation in both
 
 ## Documentation guidelines:
 
-- Write API reference documentation inline using [TSDoc-formatted](https://tsdoc.org/) comments 
-    - PR's lacking these comments will be considered incomplete
+- Please include documentation for any new definitions (e.g. classes, functions, types, const exports) that someone using the library may interact with. Write API reference documentation inline using [TSDoc-formatted](https://tsdoc.org/) comments 
+    - If at all possible, we will try to have documentation written before merging a PR. A reviewer may ask you to write documentation for a PR if it isn't already included.
 - PR's do *not* require contributor-generated usage tutorials - API Reference material is sufficient
 - Writing draft documentation is better than writing none at all
 - Documentation can and should begin immediately 
@@ -22,12 +22,10 @@ This document serves to describe `cubing.js`'s approach to documentation in both
 
 ## Style Guidelines
 
-- Technical references (ie, references to files, projects and tools) should be formatted as follows:
-  - Use backticks \` when there is no accompanying link (eg, "`cubing.js` is a project which aims to...")
-  - Omit backticks when there is an accompanying link (eg, "Make sure you have [node](https://nodejs.org/en/) installed before...")
-  - Reasoning: Universal use of backticks disguises links, leading to confusing navigation
+- Technical references (ie, references to files, projects and tools) should be formatted using backticks ("`"), as follows:
+  - "`cubing.js` is a project which aims to...
 - Draft documentation should include the following disclaimer at the top of the document:
-  - *NB: This information is still in draft form, and should not be relied upon to inform usage of or contribution to `cubing.js`.*
+  - *NB: This information is still in draft form. Do not rely on it to use or contribute to `cubing.js`.*
 
 ## Tooling (TBD)
 
@@ -36,3 +34,5 @@ Tooling for documentation is still being discussed among key contributors, and w
 ## Documentation process (TBD)
 
 The documentation process for documentation is still being discussed among key contributors, and will be added to this section once finalised.
+
+[`Example link`](alg/index.html)

--- a/docs/drafts/Documentation Guidelines.md
+++ b/docs/drafts/Documentation Guidelines.md
@@ -1,0 +1,34 @@
+## Purpose of this document
+
+This document serves to describe `cubing.js`'s approach to documentation in both practical and theoretical terms. Anyone looking to contribute either documentation or new features to `cubing.js` should consult this document.
+
+## Documentation guidelines:
+
+- Write API reference documentation inline using [TSDoc-formatted](https://tsdoc.org/) comments 
+    - PR's lacking these comments will be considered incomplete
+- PR's do *not* require contributor-generated usage tutorials - API Reference material is sufficient
+- Writing draft documentation is better than writing none at all
+- Documentation can and should begin immediately 
+  - It is *much* easier to write documentation at the time of coding. Additionally, it is much easier to improve imperfect documentation than to write it from scratch.
+
+## Documentation roadmap:
+
+- Devs to create API reference for all new modules/features going forward (prevents growth of documentation backlog)
+- Decide on documentation process and tooling
+- Create library architecture overview, and create API reference for through backlog of undocumented modules/features (serves needs of experienced developers and contributors)
+- Create tutorials/guides for how to apply the library in practice (serves needs of novice developers)
+
+## Style Guidelines
+
+- Technical references (ie, references to files, projects and tools) should be formatted as follows:
+  - Use backticks \` when there is no accompanying link (eg, "`cubing.js` is a project which aims to...")
+  - Omit backticks when there is an accompanying link (eg, "Make sure you have [node](https://nodejs.org/en/) installed before...")
+  - Reasoning: Universal use of backticks disguises links, leading to confusing navigation
+
+## Tooling (TBD)
+
+Tooling for documentation is still being discussed among key contributors, and will be added to this section once finalised.
+
+## Documentation process (TBD)
+
+The documentation process for documentation is still being discussed among key contributors, and will be added to this section once finalised.

--- a/docs/drafts/Documentation Guidelines.md
+++ b/docs/drafts/Documentation Guidelines.md
@@ -1,3 +1,5 @@
+*NB: This information is still in draft form, and should not be relied upon to inform usage of or contribution to `cubing.js`.*
+
 ## Purpose of this document
 
 This document serves to describe `cubing.js`'s approach to documentation in both practical and theoretical terms. Anyone looking to contribute either documentation or new features to `cubing.js` should consult this document.
@@ -24,6 +26,8 @@ This document serves to describe `cubing.js`'s approach to documentation in both
   - Use backticks \` when there is no accompanying link (eg, "`cubing.js` is a project which aims to...")
   - Omit backticks when there is an accompanying link (eg, "Make sure you have [node](https://nodejs.org/en/) installed before...")
   - Reasoning: Universal use of backticks disguises links, leading to confusing navigation
+- Draft documentation should include the following disclaimer at the top of the document:
+  - *NB: This information is still in draft form, and should not be relied upon to inform usage of or contribution to `cubing.js`.*
 
 ## Tooling (TBD)
 


### PR DESCRIPTION
Implicit in some of what I wrote in this PR are a number of proposals which I believe warrant input from @lgarron and @rokicki. For the sake of expediency, I wrote them as declarative statements in Documentation Guidelines, but everything here represents a proposal for discussion.

To start, I suggest we start distinguishing between 2 kinds of documentation:
- **API Reference** - describes the usage of the functions/modules which are exposed through the `cubing.js` library
- **Long-form documentation** - README, tutorials, CONTRIBUTING.md - anything that looks more like prose than function definitions.
When I use the general term "documentation", I am referring to _both_ of these.

Overall, these proposals aim to do 3 things:
1. Present a roadmap for addressing the current documentation backlog 
2. Prevent the growth of the documentation backlog by encouraging API reference documentation "as we go"
3. Introduce the concept of "Draft" documentation to make it easy to "jot down" long-form documentation as it comes to us (as this document did to me), rather than feel that if we are going to write any documentation at all it has to be perfect.

## Proposals:
(a) All **new** modules/functions added should only be accepted/considered complete if they are accompanied by API Reference documentation - in line with (2) above
(b) Store draft documentation in `/docs/draft`, so that the drafts people come up with are shared and can be taken forward by someone else if needed
(c) Not backtick technical references when they include links, to prevent ambiguity (this comes out of my experience of trying to browse the README
(d) See `Documentation roadmap` section for my proposed roadmap for tackling the current documentation backlog

Discussion welcome, hence the draft nature of this PR. Once/if considered by both of you and agreed, we can merge.