### PR TITLE
[twisty] DragTracker: Switch to pure `movementX`/`movementY`.

### DIFF
--- a/src/cubing/twisty/views/3D/DragTracker.ts
+++ b/src/cubing/twisty/views/3D/DragTracker.ts
@@ -5,8 +5,6 @@
 interface DragInfo {
   attachedInfo: Record<any, any>;
   hasMoved: boolean;
-  lastClientX: number;
-  lastClientY: number;
   lastTimeStamp: number;
 }
 
@@ -106,35 +104,13 @@ export class DragTracker extends EventTarget {
     if (!existing) {
       return { movementInfo: null, hasMoved: false };
     }
-    // We would try to use `e.movementX`/`e.movementY`, except Safari:
-    // - Does not have those values on i[Pad]OS.
-    // - Will always report `0` for these values on macOS.
-    // https://bugs.webkit.org/show_bug.cgi?id=220194
-    //
-    // The following are all insufficiently powerful for detecting the Safari `0` bug:
-    // - `"movementX" in e`
-    // - `e.movementX !== "undefined"`
-    // - `e.hasOwnProperty("movementX")`
-
-    let movementInfo: DragMovementInfo;
-    if ((e.movementX ?? 0) !== 0 || (e.movementY ?? 0) !== 0) {
-      // We optimistically try to catch sub-pixel movements in Chrome.
-      movementInfo = {
-        attachedInfo: existing.attachedInfo,
-        movementX: e.movementX,
-        movementY: e.movementY,
-        elapsedMs: e.timeStamp - existing.lastTimeStamp,
-      };
-    } else {
-      movementInfo = {
-        attachedInfo: existing.attachedInfo,
-        movementX: e.clientX - existing.lastClientX,
-        movementY: e.clientY - existing.lastClientY,
-        elapsedMs: e.timeStamp - existing.lastTimeStamp,
-      };
-    }
-    existing.lastClientX = e.clientX;
-    existing.lastClientY = e.clientY;
+    // We optimistically try to catch sub-pixel movements in Chrome.
+    const movementInfo: DragMovementInfo = {
+      attachedInfo: existing.attachedInfo,
+      movementX: e.movementX,
+      movementY: e.movementY,
+      elapsedMs: e.timeStamp - existing.lastTimeStamp,
+    };
     existing.lastTimeStamp = e.timeStamp;
     if (
       Math.abs(movementInfo.movementX) < MOVEMENT_EPSILON &&
@@ -152,8 +128,6 @@ export class DragTracker extends EventTarget {
     const newDragInfo: DragInfo = {
       attachedInfo: {},
       hasMoved: false,
-      lastClientX: e.clientX,
-      lastClientY: e.clientY,
       lastTimeStamp: e.timeStamp,
     };
     this.#dragInfoMap.set(e.pointerId, newDragInfo);


### PR DESCRIPTION
We can do this now that https://bugs.webkit.org/show_bug.cgi?id=220194 is fixed in Safari 15.5.