### PR TITLE
An uncompiled attempt to override equal for Alg tests.

### DIFF
--- a/src/cubing/alg/operation.spec.ts
+++ b/src/cubing/alg/operation.spec.ts
@@ -6,7 +6,7 @@ import { Move } from "./alg-nodes";
 
 use(function (chai, utils) {
   chai.Assertion.overwriteMethod("equal", function (_super) {
-    return function compareAlgs(other) {
+    return function compareAlgs(other: any) {
       const obj = this._obj;
       if (obj && obj instanceof Alg) {
         const actualString = obj.toString();

--- a/src/cubing/alg/operation.spec.ts
+++ b/src/cubing/alg/operation.spec.ts
@@ -1,16 +1,30 @@
-import { expect } from "../../test/chai-workaround";
+import { expect, use } from "../../test/chai-workaround";
 
 import { Alg } from "./Alg";
 import { experimentalAppendMove } from "./operation";
 import { Move } from "./alg-nodes";
 
+use(function (chai, utils) {
+  chai.Assertion.overwriteMethod("equal", function (_super) {
+    return function compareAlgs(other) {
+      const obj = this._obj;
+      if (obj && obj instanceof Alg) {
+        const actualString = obj.toString();
+        const expectedString = other.toString();
+        expect(actualString).to.equal(expectedString);
+        expect(obj.isIdentical(other));
+      } else {
+        _super.apply(this, arguments);
+      }
+    };
+  });
+});
+
 describe("operation", () => {
   it("can append moves", () => {
-    expect(
-      experimentalAppendMove(new Alg("R U R'"), new Move("U2")).isIdentical(
-        new Alg("R U R' U2"),
-      ),
-    ).to.be.true;
+    expect(experimentalAppendMove(new Alg("R U R'"), new Move("U2"))).to.equal(
+      new Alg("R U R' U"),
+    );
     expect(
       experimentalAppendMove(new Alg("R U R'"), new Move("R", -2)).isIdentical(
         new Alg("R U R' R2'"),
@@ -44,22 +58,26 @@ describe("operation", () => {
   it("computes mod offsets correctly", () => {
     expect(
       experimentalAppendMove(new Alg("L3"), new Move("L"), {
-        coalesce: true, mod: 4,
+        coalesce: true,
+        mod: 4,
       }).isIdentical(new Alg("")),
     ).to.be.true;
     expect(
       experimentalAppendMove(new Alg("L3"), new Move("L3"), {
-        coalesce: true, mod: 4,
+        coalesce: true,
+        mod: 4,
       }).isIdentical(new Alg("L2")),
     ).to.be.true;
     expect(
       experimentalAppendMove(new Alg("L3"), new Move("L6"), {
-        coalesce: true, mod: 4,
+        coalesce: true,
+        mod: 4,
       }).isIdentical(new Alg("L")),
     ).to.be.true;
     expect(
       experimentalAppendMove(new Alg("L"), new Move("L"), {
-        coalesce: true, mod: 3,
+        coalesce: true,
+        mod: 3,
       }).isIdentical(new Alg("L'")),
     ).to.be.true;
   });

--- a/src/test/chai-workaround/index.ts
+++ b/src/test/chai-workaround/index.ts
@@ -7,5 +7,8 @@
  * So we work around both issues here.
  */
 
-const { expect: untypedExpect } = await import("@esm-bundle" + "/chai");
+const { expect: untypedExpect, use: untypedUse } = await import(
+  "@esm-bundle" + "/chai"
+);
 export const expect: typeof import("chai").expect = untypedExpect;
+export const use: typeof import("chai").use = untypedUse;


### PR DESCRIPTION
A helper for legible alg comparisons if you assert alg equality in a test.

NOT FOR COMMIT. To finish this PR, I would move the helper into a sharable location, find all Alg comparisons in tests, and convert them to expect(thingThatComputesAlg()).to.equal(expectedalg). I don't want to bother with that if the actual solution proposed here is not wanted as it's a lot of edits and a big rebase on my own code which will not merge cleanly with this approach.