### PR TITLE
Wide slice

### DIFF
--- a/src/cubing/alg/operation.spec.ts
+++ b/src/cubing/alg/operation.spec.ts
@@ -101,32 +101,32 @@ describe("operation", () => {
   it("wide moves", () => {
     expect(
       experimentalAppendMove(new Alg("L"), new Move("x"), {
-        wideMoves: true,
+        wideMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("r"));
     expect(
       experimentalAppendMove(new Alg("L'"), new Move("x'"), {
-        wideMoves: true,
+        wideMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("r'"));
     expect(
       experimentalAppendMove(new Alg("R"), new Move("x'"), {
-        wideMoves: true,
+        wideMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("l"));
     expect(
       experimentalAppendMove(new Alg("R"), new Move("x"), {
-        wideMoves: true,
+        wideMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("R x"));
     expect(
       experimentalAppendMove(new Alg("R'"), new Move("x"), {
-        wideMoves: true,
+        wideMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("l'"));
     expect(
       experimentalAppendMove(new Alg("R' R"), new Move("x"), {
-        wideMoves: true,
+        wideMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("R' R x"));
   });
@@ -134,32 +134,32 @@ describe("operation", () => {
   it("slice moves", () => {
     expect(
       experimentalAppendMove(new Alg("R' R"), new Move("x"), {
-        wideMoves: true,
-        sliceMoves: true,
+        wideMoves333: true,
+        sliceMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("R' R x"));
     expect(
       experimentalAppendMove(new Alg("L' R"), new Move("x'"), {
-        wideMoves: true,
-        sliceMoves: true,
+        wideMoves333: true,
+        sliceMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("M"));
     expect(
       experimentalAppendMove(new Alg("L R'"), new Move("x"), {
-        wideMoves: true,
-        sliceMoves: true,
+        wideMoves333: true,
+        sliceMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("M'"));
     expect(
       experimentalAppendMove(new Alg("L' R"), new Move("x"), {
-        wideMoves: true,
-        sliceMoves: true,
+        wideMoves333: true,
+        sliceMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("L' R x"));
     expect(
       experimentalAppendMove(new Alg("U' D"), new Move("y"), {
-        wideMoves: true,
-        sliceMoves: true,
+        wideMoves333: true,
+        sliceMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("E'"));
   });

--- a/src/cubing/alg/operation.spec.ts
+++ b/src/cubing/alg/operation.spec.ts
@@ -129,6 +129,42 @@ describe("operation", () => {
         wideMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("R' R x"));
+    expect(
+      experimentalAppendMove(new Alg("L2"), new Move("x2"), {
+        wideMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("r2"));
+    expect(
+      experimentalAppendMove(new Alg("x"), new Move("L"), {
+        wideMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("x L"));
+    expect(
+      experimentalAppendMove(new Alg("r L"), new Move("x"), {
+        wideMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("r r"));
+  });
+
+  it("wide moves with sameDirection", () => {
+    expect(
+      experimentalAppendMove(new Alg("L"), new Move("x"), {
+        wideMoves333: true,
+        sameDirection: true,
+      }),
+    ).to.be.identicalAlg(new Alg("r"));
+    expect(
+      experimentalAppendMove(new Alg("r"), new Move("L"), {
+        wideMoves333: true,
+        sameDirection: true,
+      }),
+    ).to.be.identicalAlg(new Alg("r L"));
+    expect(
+      experimentalAppendMove(new Alg("r L"), new Move("x"), {
+        wideMoves333: true,
+        sameDirection: true,
+      }),
+    ).to.be.identicalAlg(new Alg("r2"));
   });
 
   it("slice moves", () => {
@@ -162,6 +198,84 @@ describe("operation", () => {
         sliceMoves333: true,
       }),
     ).to.be.identicalAlg(new Alg("E'"));
+    expect(
+      experimentalAppendMove(new Alg("U D'"), new Move("y'"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("E"));
+    expect(
+      experimentalAppendMove(new Alg("F B'"), new Move("z'"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("S'"));
+    expect(
+      experimentalAppendMove(new Alg("F' B"), new Move("z"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("S"));
+    expect(
+      experimentalAppendMove(new Alg("L R'"), new Move("x'"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("L R' x'"));
+    expect(
+      experimentalAppendMove(new Alg("U' D"), new Move("y'"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("U' D y'"));
+    expect(
+      experimentalAppendMove(new Alg("U D'"), new Move("y"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("U D' y"));
+    expect(
+      experimentalAppendMove(new Alg("F B'"), new Move("z"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("F B' z"));
+    expect(
+      experimentalAppendMove(new Alg("F' B"), new Move("z'"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("F' B z'"));
+    expect(
+      experimentalAppendMove(new Alg("x L"), new Move("R"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("x L R"));
+    expect(
+      experimentalAppendMove(new Alg("L2' R2"), new Move("x2'"), {
+        wideMoves333: true,
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("M2"));
+  });
+
+  it("slice moves only", () => {
+    expect(
+      experimentalAppendMove(new Alg("R"), new Move("x"), {
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("R x"));
+    expect(
+      experimentalAppendMove(new Alg("R x"), new Move("L'"), {
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("R x L'"));
+    expect(
+      experimentalAppendMove(new Alg("L2' R2"), new Move("x2'"), {
+        sliceMoves333: true,
+      }),
+    ).to.be.identicalAlg(new Alg("M2"));
   });
 
   it("can concat algs", () => {

--- a/src/cubing/alg/operation.spec.ts
+++ b/src/cubing/alg/operation.spec.ts
@@ -66,6 +66,18 @@ describe("operation", () => {
         mod: 3,
       }),
     ).to.be.identicalAlg(new Alg("L'"));
+    expect(
+      experimentalAppendMove(new Alg("L3"), new Move("L3"), {
+        coalesce: true,
+        mod: 3,
+      }),
+    ).to.be.identicalAlg(new Alg(""));
+    expect(
+      experimentalAppendMove(new Alg("L3"), new Move("L6"), {
+        coalesce: true,
+        mod: 3,
+      }),
+    ).to.be.identicalAlg(new Alg(""));
   });
 
   it("can concat algs", () => {

--- a/src/cubing/alg/operation.spec.ts
+++ b/src/cubing/alg/operation.spec.ts
@@ -80,6 +80,78 @@ describe("operation", () => {
     ).to.be.identicalAlg(new Alg(""));
   });
 
+  it("wide moves not processed by default", () => {
+    expect(
+      experimentalAppendMove(new Alg("L"), new Move("x")),
+    ).to.be.identicalAlg(new Alg("L x"));
+  });
+
+  it("wide moves", () => {
+    expect(
+      experimentalAppendMove(new Alg("L"), new Move("x"), {
+        wideMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("r"));
+    expect(
+      experimentalAppendMove(new Alg("L'"), new Move("x'"), {
+        wideMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("r'"));
+    expect(
+      experimentalAppendMove(new Alg("R"), new Move("x'"), {
+        wideMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("l"));
+    expect(
+      experimentalAppendMove(new Alg("R"), new Move("x"), {
+        wideMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("R x"));
+    expect(
+      experimentalAppendMove(new Alg("R'"), new Move("x"), {
+        wideMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("l'"));
+    expect(
+      experimentalAppendMove(new Alg("R' R"), new Move("x"), {
+        wideMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("R' R x"));
+  });
+
+  it("slice moves", () => {
+    expect(
+      experimentalAppendMove(new Alg("R' R"), new Move("x"), {
+        wideMoves: true,
+        sliceMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("R' R x"));
+    expect(
+      experimentalAppendMove(new Alg("L' R"), new Move("x'"), {
+        wideMoves: true,
+        sliceMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("M"));
+    expect(
+      experimentalAppendMove(new Alg("L R'"), new Move("x"), {
+        wideMoves: true,
+        sliceMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("M'"));
+    expect(
+      experimentalAppendMove(new Alg("L' R"), new Move("x"), {
+        wideMoves: true,
+        sliceMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("L' R x"));
+    expect(
+      experimentalAppendMove(new Alg("U' D"), new Move("y"), {
+        wideMoves: true,
+        sliceMoves: true,
+      }),
+    ).to.be.identicalAlg(new Alg("E'"));
+  });
+
   it("can concat algs", () => {
     expect(
       new Alg("R U2").concat(new Alg("F' D")).isIdentical(new Alg("R U2 F' D")),

--- a/src/cubing/alg/operation.spec.ts
+++ b/src/cubing/alg/operation.spec.ts
@@ -20,41 +20,50 @@ describe("operation", () => {
   it("can coalesce appended moves", () => {
     expect(
       experimentalAppendMove(new Alg("R U R'"), new Move("U2"), {
-        coalesce: true,
+        sameDirection: true,
+        oppositeDirection: true,
       }),
     ).to.be.identicalAlg(new Alg("R U R' U2"));
     expect(
       experimentalAppendMove(new Alg("R U R'"), new Move("R2'"), {
-        coalesce: true,
+        sameDirection: true,
+        oppositeDirection: true,
       }),
     ).to.be.identicalAlg(new Alg("R U R3'"));
     expect(
       experimentalAppendMove(new Alg("R U R'"), new Move("R"), {
-        coalesce: true,
+        sameDirection: true,
+        oppositeDirection: true,
       }),
     ).to.be.identicalAlg(new Alg("R U"));
     expect(
-      experimentalAppendMove(new Alg("r"), new Move("r"), { coalesce: true }),
+      experimentalAppendMove(new Alg("r"), new Move("r"), {
+        sameDirection: true,
+        oppositeDirection: true,
+      }),
     ).to.be.identicalAlg(new Alg("r2"));
   });
 
   it("mod 4 works as expected", () => {
     expect(
       experimentalAppendMove(new Alg("L3"), new Move("L"), {
-        coalesce: true,
-        mod: 4,
+        sameDirection: true,
+        oppositeDirection: true,
+        quantumMoveOrder: 4,
       }),
     ).to.be.identicalAlg(new Alg(""));
     expect(
       experimentalAppendMove(new Alg("L3"), new Move("L3"), {
-        coalesce: true,
-        mod: 4,
+        sameDirection: true,
+        oppositeDirection: true,
+        quantumMoveOrder: 4,
       }),
     ).to.be.identicalAlg(new Alg("L2"));
     expect(
       experimentalAppendMove(new Alg("L3"), new Move("L6"), {
-        coalesce: true,
-        mod: 4,
+        sameDirection: true,
+        oppositeDirection: true,
+        quantumMoveOrder: 4,
       }),
     ).to.be.identicalAlg(new Alg("L"));
   });
@@ -62,20 +71,23 @@ describe("operation", () => {
   it("mod 3 works as expected", () => {
     expect(
       experimentalAppendMove(new Alg("L"), new Move("L"), {
-        coalesce: true,
-        mod: 3,
+        sameDirection: true,
+        oppositeDirection: true,
+        quantumMoveOrder: 3,
       }),
     ).to.be.identicalAlg(new Alg("L'"));
     expect(
       experimentalAppendMove(new Alg("L3"), new Move("L3"), {
-        coalesce: true,
-        mod: 3,
+        sameDirection: true,
+        oppositeDirection: true,
+        quantumMoveOrder: 3,
       }),
     ).to.be.identicalAlg(new Alg(""));
     expect(
       experimentalAppendMove(new Alg("L3"), new Move("L6"), {
-        coalesce: true,
-        mod: 3,
+        sameDirection: true,
+        oppositeDirection: true,
+        quantumMoveOrder: 3,
       }),
     ).to.be.identicalAlg(new Alg(""));
   });

--- a/src/cubing/alg/operation.ts
+++ b/src/cubing/alg/operation.ts
@@ -4,8 +4,8 @@ import type { Move } from "./alg-nodes/leaves/Move";
 export interface ExperimentalCollapseOptions {
   sameDirection?: boolean;
   oppositeDirection?: boolean;
-  wideMoves?: boolean;
-  sliceMoves?: boolean;
+  wideMoves333?: boolean;
+  sliceMoves333?: boolean;
   quantumMoveOrder?: number;
 }
 
@@ -19,7 +19,7 @@ export function experimentalAppendMove(
   const preLastMove = oldAlgNodes[oldAlgNodes.length - 2] as Move | undefined;
   const directionsAligned = lastMove && lastMove.amount * newMove.amount > 0;
   if (
-    options?.sliceMoves &&
+    options?.sliceMoves333 &&
     "xyz".indexOf(newMove.family) !== -1 &&
     lastMove &&
     lastMove.quantum &&
@@ -51,7 +51,7 @@ export function experimentalAppendMove(
     }
   }
   if (
-    options?.wideMoves &&
+    options?.wideMoves333 &&
     "xyz".indexOf(newMove.family) !== -1 &&
     lastMove &&
     lastMove.quantum

--- a/src/cubing/alg/operation.ts
+++ b/src/cubing/alg/operation.ts
@@ -44,8 +44,11 @@ export function experimentalAppendMove(
         if (checkMove.amount === -newMove.amount) {
           const family = "MES"[index];
           const amount = family === "S" ? newMove.amount : -newMove.amount;
-          newAlgNodes.push(newMove.modified({ family, amount }));
-          return new Alg(newAlgNodes);
+          return experimentalAppendMove(
+            new Alg(newAlgNodes),
+            newMove.modified({ family, amount }),
+            options,
+          );
         }
       }
     }
@@ -66,13 +69,19 @@ export function experimentalAppendMove(
     if (checkMove === lastFamily) {
       if (lastMove.amount === newMove.amount) {
         const family = "ruf"[index];
-        newAlgNodes.push(lastMove.modified({ family }));
-        return new Alg(newAlgNodes);
+        return experimentalAppendMove(
+          new Alg(newAlgNodes),
+          lastMove.modified({ family }),
+          options,
+        );
       }
       if (lastMove.amount === -newMove.amount) {
         const family = "ldb"[index];
-        newAlgNodes.push(lastMove.modified({ family }));
-        return new Alg(newAlgNodes);
+        return experimentalAppendMove(
+          new Alg(newAlgNodes),
+          lastMove.modified({ family }),
+          options,
+        );
       }
     }
   }

--- a/src/cubing/alg/operation.ts
+++ b/src/cubing/alg/operation.ts
@@ -6,19 +6,80 @@ export function experimentalAppendMove(
   newMove: Move,
   options?: {
     coalesce?: boolean; // defaults to false
+    wideMoves?: boolean; // defaults to false
+    sliceMoves?: boolean; // defaults to false
     mod?: number;
   },
 ): Alg {
   const oldAlgNodes = Array.from(alg.childAlgNodes());
-  const oldLastMove = oldAlgNodes[oldAlgNodes.length - 1] as Move | undefined;
+  const lastMove = oldAlgNodes[oldAlgNodes.length - 1] as Move | undefined;
+  const preLastMove = oldAlgNodes[oldAlgNodes.length - 2] as Move | undefined;
+  if (
+    options?.sliceMoves &&
+    "xyz".indexOf(newMove.family) !== -1 &&
+    lastMove &&
+    lastMove.quantum &&
+    preLastMove &&
+    preLastMove.quantum
+  ) {
+    const index = "xyz".indexOf(newMove.family);
+    const forwardMove = "LDB"[index];
+    const inverseMove = "RUF"[index];
+    const newAlgNodes = oldAlgNodes.slice(0, oldAlgNodes.length - 2);
+    const lastFamily = lastMove.family;
+    const preLastFamily = preLastMove.family;
+    if (
+      (forwardMove === lastFamily && inverseMove === preLastFamily) ||
+      (inverseMove === lastFamily && forwardMove === preLastFamily)
+    ) {
+      if (lastMove.amount === -preLastMove.amount) {
+        let checkMove = lastMove;
+        if (inverseMove === preLastFamily) {
+          checkMove = preLastMove;
+        }
+        if (checkMove.amount === -newMove.amount) {
+          const family = "MES"[index];
+          const amount = family === "S" ? newMove.amount : -newMove.amount;
+          newAlgNodes.push(newMove.modified({ family, amount }));
+          return new Alg(newAlgNodes);
+        }
+      }
+    }
+  }
+  if (
+    options?.wideMoves &&
+    "xyz".indexOf(newMove.family) !== -1 &&
+    lastMove &&
+    lastMove.quantum
+  ) {
+    const index = "xyz".indexOf(newMove.family);
+    const forwardMove = "LDB"[index];
+    const inverseMove = "RUF"[index];
+    const moveAlignment = newMove.amount * lastMove.amount;
+    const checkMove = moveAlignment > 0 ? forwardMove : inverseMove;
+    const newAlgNodes = oldAlgNodes.slice(0, oldAlgNodes.length - 1);
+    const lastFamily = lastMove.family;
+    if (checkMove === lastFamily) {
+      if (lastMove.amount === newMove.amount) {
+        const family = "ruf"[index];
+        newAlgNodes.push(lastMove.modified({ family }));
+        return new Alg(newAlgNodes);
+      }
+      if (lastMove.amount === -newMove.amount) {
+        const family = "ldb"[index];
+        newAlgNodes.push(lastMove.modified({ family }));
+        return new Alg(newAlgNodes);
+      }
+    }
+  }
   if (
     options?.coalesce &&
-    oldLastMove &&
-    oldLastMove.quantum &&
-    oldLastMove.quantum.isIdentical(newMove.quantum)
+    lastMove &&
+    lastMove.quantum &&
+    lastMove.quantum.isIdentical(newMove.quantum)
   ) {
     const newAlgNodes = oldAlgNodes.slice(0, oldAlgNodes.length - 1);
-    let newAmount = oldLastMove.amount + newMove.amount;
+    let newAmount = lastMove.amount + newMove.amount;
     const mod = options?.mod;
     if (mod) {
       newAmount = ((newAmount % mod) + mod) % mod;
@@ -27,10 +88,9 @@ export function experimentalAppendMove(
       }
     }
     if (newAmount !== 0) {
-      newAlgNodes.push(oldLastMove.modified({ amount: newAmount }));
+      newAlgNodes.push(lastMove.modified({ amount: newAmount }));
     }
     return new Alg(newAlgNodes);
-  } else {
-    return new Alg([...oldAlgNodes, newMove]);
   }
+  return new Alg([...oldAlgNodes, newMove]);
 }

--- a/src/cubing/twisty/model/TwistyPlayerModel.ts
+++ b/src/cubing/twisty/model/TwistyPlayerModel.ts
@@ -262,7 +262,15 @@ export class TwistyPlayerModel {
     this.alg.set(
       (async () => {
         const alg = (await this.alg.get()).alg;
-        const newAlg = experimentalAppendMove(alg, move, options);
+        const addOptions = {
+          sliceMoves: options?.sliceMoves,
+          wideMoves: options?.wideMoves,
+          quantumMoveOrder: options?.mod,
+          sameDirection: options?.coalesce,
+          oppositeDirection: options?.coalesce,
+        };
+
+        const newAlg = experimentalAppendMove(alg, move, addOptions);
         this.timestampRequest.set("end");
         this.catchUpMove.set({
           move: move,

--- a/src/cubing/twisty/model/TwistyPlayerModel.ts
+++ b/src/cubing/twisty/model/TwistyPlayerModel.ts
@@ -227,8 +227,8 @@ export class TwistyPlayerModel {
     algLeaf: AlgLeaf,
     options: {
       coalesce?: boolean;
-      sliceMoves?: boolean;
-      wideMoves?: boolean;
+      sliceMoves333?: boolean;
+      wideMoves333?: boolean;
       mod?: number;
     } = {},
   ): void {
@@ -252,8 +252,8 @@ export class TwistyPlayerModel {
     flexibleMove: Move | string,
     options: {
       coalesce?: boolean;
-      sliceMoves?: boolean;
-      wideMoves?: boolean;
+      sliceMoves333?: boolean;
+      wideMoves333?: boolean;
       mod?: number;
     } = {},
   ): void {
@@ -263,8 +263,8 @@ export class TwistyPlayerModel {
       (async () => {
         const alg = (await this.alg.get()).alg;
         const addOptions = {
-          sliceMoves: options?.sliceMoves,
-          wideMoves: options?.wideMoves,
+          sliceMoves333: options?.sliceMoves333,
+          wideMoves333: options?.wideMoves333,
           quantumMoveOrder: options?.mod,
           sameDirection: options?.coalesce,
           oppositeDirection: options?.coalesce,

--- a/src/cubing/twisty/model/TwistyPlayerModel.ts
+++ b/src/cubing/twisty/model/TwistyPlayerModel.ts
@@ -225,7 +225,12 @@ export class TwistyPlayerModel {
 
   experimentalAddAlgLeaf(
     algLeaf: AlgLeaf,
-    options: { coalesce?: boolean; mod?: number } = {},
+    options: {
+      coalesce?: boolean;
+      sliceMoves?: boolean;
+      wideMoves?: boolean;
+      mod?: number;
+    } = {},
   ): void {
     const maybeMove = algLeaf.as(Move);
     if (maybeMove) {
@@ -245,17 +250,19 @@ export class TwistyPlayerModel {
   // TODO: Animate the new move.
   experimentalAddMove(
     flexibleMove: Move | string,
-    options: { coalesce?: boolean; mod?: number } = {},
+    options: {
+      coalesce?: boolean;
+      sliceMoves?: boolean;
+      wideMoves?: boolean;
+      mod?: number;
+    } = {},
   ): void {
     const move =
       typeof flexibleMove === "string" ? new Move(flexibleMove) : flexibleMove;
     this.alg.set(
       (async () => {
         const alg = (await this.alg.get()).alg;
-        const newAlg = experimentalAppendMove(alg, move, {
-          coalesce: options?.coalesce,
-          mod: options?.mod,
-        });
+        const newAlg = experimentalAppendMove(alg, move, options);
         this.timestampRequest.set("end");
         this.catchUpMove.set({
           move: move,

--- a/src/cubing/twisty/views/TwistyPlayer.ts
+++ b/src/cubing/twisty/views/TwistyPlayer.ts
@@ -411,8 +411,8 @@ export class TwistyPlayer
     flexibleMove: Move | string,
     options: {
       coalesce?: boolean;
-      wideMoves?: boolean;
-      sliceMoves?: boolean;
+      wideMoves333?: boolean;
+      sliceMoves333?: boolean;
     } = {},
   ): void {
     this.experimentalModel.experimentalAddMove(flexibleMove, options);
@@ -423,8 +423,8 @@ export class TwistyPlayer
     algLeaf: AlgLeaf,
     options: {
       coalesce?: boolean;
-      wideMoves?: boolean;
-      sliceMoves?: boolean;
+      wideMoves333?: boolean;
+      sliceMoves333?: boolean;
     } = {},
   ): void {
     this.experimentalModel.experimentalAddAlgLeaf(algLeaf, options);

--- a/src/cubing/twisty/views/TwistyPlayer.ts
+++ b/src/cubing/twisty/views/TwistyPlayer.ts
@@ -409,7 +409,11 @@ export class TwistyPlayer
   // TODO: Animate the new move.
   experimentalAddMove(
     flexibleMove: Move | string,
-    options: { coalesce?: boolean } = {},
+    options: {
+      coalesce?: boolean;
+      wideMoves?: boolean;
+      sliceMoves?: boolean;
+    } = {},
   ): void {
     this.experimentalModel.experimentalAddMove(flexibleMove, options);
   }
@@ -417,7 +421,11 @@ export class TwistyPlayer
   // TODO: Animate the new move.
   experimentalAddAlgLeaf(
     algLeaf: AlgLeaf,
-    options: { coalesce?: boolean } = {},
+    options: {
+      coalesce?: boolean;
+      wideMoves?: boolean;
+      sliceMoves?: boolean;
+    } = {},
   ): void {
     this.experimentalModel.experimentalAddAlgLeaf(algLeaf, options);
   }

--- a/src/sites/experiments.cubing.net/cubing.js/play/input/SwipeyPuzzle.ts
+++ b/src/sites/experiments.cubing.net/cubing.js/play/input/SwipeyPuzzle.ts
@@ -6,7 +6,13 @@ import {
   TwistyPlayer,
   TwistyPlayerConfig,
 } from "../../../../../cubing/twisty";
-import { coalesce, getSetup, PuzzleID } from "../url-params";
+import {
+  coalesce,
+  getSetup,
+  PuzzleID,
+  sliceMoves,
+  wideMoves,
+} from "../url-params";
 import { SwipeGrid, themes, ThemeType } from "./SwipeGrid";
 
 const DEFAULT_THEME: ThemeType = "transparent-grid";
@@ -192,6 +198,8 @@ export class SwipeyPuzzle extends HTMLElement {
       // TODO: allow`TwistyPlayer` to handle this directly.
       this.twistyPlayer.experimentalAddAlgLeaf(algLeaf, {
         coalesce: coalesce(),
+        wideMoves: wideMoves(),
+        sliceMoves: sliceMoves(),
       });
     } catch (e) {
       console.warn("Invalid alg leaf");

--- a/src/sites/experiments.cubing.net/cubing.js/play/input/SwipeyPuzzle.ts
+++ b/src/sites/experiments.cubing.net/cubing.js/play/input/SwipeyPuzzle.ts
@@ -10,8 +10,8 @@ import {
   coalesce,
   getSetup,
   PuzzleID,
-  sliceMoves,
-  wideMoves,
+  sliceMoves333,
+  wideMoves333,
 } from "../url-params";
 import { SwipeGrid, themes, ThemeType } from "./SwipeGrid";
 
@@ -198,8 +198,8 @@ export class SwipeyPuzzle extends HTMLElement {
       // TODO: allow`TwistyPlayer` to handle this directly.
       this.twistyPlayer.experimentalAddAlgLeaf(algLeaf, {
         coalesce: coalesce(),
-        wideMoves: wideMoves(),
-        sliceMoves: sliceMoves(),
+        wideMoves333: wideMoves333(),
+        sliceMoves333: sliceMoves333(),
       });
     } catch (e) {
       console.warn("Invalid alg leaf");

--- a/src/sites/experiments.cubing.net/cubing.js/play/url-params.ts
+++ b/src/sites/experiments.cubing.net/cubing.js/play/url-params.ts
@@ -64,6 +64,24 @@ export function coalesce(): boolean {
   );
 }
 
+export function sliceMoves(): boolean {
+  return (
+    getURLParamChecked<"true" | "false">("sliceMoves", "true", [
+      "true",
+      "false",
+    ]) === "true"
+  );
+}
+
+export function wideMoves(): boolean {
+  return (
+    getURLParamChecked<"true" | "false">("wideMoves", "true", [
+      "true",
+      "false",
+    ]) === "true"
+  );
+}
+
 export function sendingSocketOrigin(): string | null {
   return new URL(document.location.href).searchParams.get(
     "sendingSocketOrigin",

--- a/src/sites/experiments.cubing.net/cubing.js/play/url-params.ts
+++ b/src/sites/experiments.cubing.net/cubing.js/play/url-params.ts
@@ -64,18 +64,18 @@ export function coalesce(): boolean {
   );
 }
 
-export function sliceMoves(): boolean {
+export function sliceMoves333(): boolean {
   return (
-    getURLParamChecked<"true" | "false">("sliceMoves", "true", [
+    getURLParamChecked<"true" | "false">("sliceMoves333", "true", [
       "true",
       "false",
     ]) === "true"
   );
 }
 
-export function wideMoves(): boolean {
+export function wideMoves333(): boolean {
   return (
-    getURLParamChecked<"true" | "false">("wideMoves", "true", [
+    getURLParamChecked<"true" | "false">("wideMoves333", "true", [
       "true",
       "false",
     ]) === "true"


### PR DESCRIPTION
A first pass at introducing `ExperimentalCollapseOptions` so that `experimentalAddMove` can have the behaviours a roux solver would need.

I stopped short of pushing these options up to the element parameters so that we can check the shape of it before I change the public facing API. It isn't clear to me whether we'd prefer to keep supporting `coalesce` at the element level (it would mean sameDirection=oppositeDirection=true) and just add support for `sameDirection` and `oppositeDirection` or if we'd prefer to remove coalesce from the API and update all call sites.