### PR TITLE
Use `actions/upload-pages-artifact` to handle tar creation

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,6 +1,8 @@
 name: GitHub Pages
 
-on: [push]
+on:
+  push:
+    branches: [main, pages-test]
 
 jobs:
   build-and-deploy-pages:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,25 +1,40 @@
 name: GitHub Pages
 
-on:
-  push:
-    branches: [main, pages-test]
-
-# Allow one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
+on: [push]
 
 jobs:
-  build:
+  build-pages:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
 
     steps:
       - uses: actions/checkout@v2
+      # From https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          # npm cache files are stored in `~/.npm` on Linux/macOS
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci
       - run: mkdir -p ./dist/sites/js.cubing.net/
       - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
-      - run: ls -al ./dist/sites/js.cubing.net/index.html
-      - run: sudo chown -R root ./dist/sites/js.cubing.net/ # https://github.com/actions/deploy-pages/issues/58
-      - run: ls -al ./dist/sites/js.cubing.net/index.html
+      - run: find dist -type l -ls
+      - run: rm -rf dist/**/.nojekyll
+      - run: find dist -type l -ls
       - name: Upload artifact
         uses: actions/upload-artifact@main
         with:
@@ -27,24 +42,22 @@ jobs:
           path: ./dist/sites/js.cubing.net/
           retention-days: 1
 
-  # Deploy job
-  deploy:
-    # Add a dependency to the build job
-    needs: build
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    # Deploy to the github-pages environment
+  deploy-pages:
+    runs-on: ubuntu-latest
+    needs: build-pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
 
-    # Specify runner + deployment step
-    runs-on: ubuntu-latest
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    # https://github.com/actions/deploy-pages#usage
+    permissions:
+      contents: read
+      pages: write      # to deploy to Pages
+      deployments: write
+      id-token: write   # to verify the deployment originates from an appropriate source
+
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@main
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,6 +35,7 @@ jobs:
       - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
       - run: find dist -type l -ls
       - run: rm -rf dist/**/.nojekyll
+      - run: chmod -R 777 ./dist
       - run: sudo chown -R root ./dist/
       - run: find dist -type l -ls
       - name: Upload artifact

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,9 +42,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: mkdir -p ./dist/
-      - run: echo "js.cubing.net" > ./dist/CNAME
-      - run: echo "hi!" > ./dist/index.html
+      - run: mkdir -p ./dist/sites/js.cubing.net/
+      - run: echo "js.cubing.net" > ./dist/sites/js.cubing.net/CNAME
+      - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
       - run: find dist -type l -ls
       - run: rm -rf dist/**/.nojekyll
       - run: chmod -R 777 ./dist
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: github-pages
-          path: ./dist/
+          path: ./dist/sites/js.cubing.net/
           retention-days: 1
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,7 +18,7 @@ jobs:
       - run: mkdir -p ./dist/sites/js.cubing.net/
       - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
       - run: ls -al ./dist/sites/js.cubing.net/index.html
-      - run: chown -R root ./dist/sites/js.cubing.net/
+      - run: sudo chown -R root ./dist/sites/js.cubing.net/ # https://github.com/actions/deploy-pages/issues/58
       - run: ls -al ./dist/sites/js.cubing.net/index.html
       - name: Upload artifact
         uses: actions/upload-artifact@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -42,9 +42,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: mkdir -p ./dist/sites/js.cubing.net/
-      - run: echo "js.cubing.net" > ./dist/sites/js.cubing.net/CNAME
-      - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
+      - run: mkdir -p ./dist/
+      - run: echo "js.cubing.net" > ./dist/CNAME
+      - run: echo "hi!" > ./dist/index.html
       - run: find dist -type l -ls
       - run: rm -rf dist/**/.nojekyll
       - run: chmod -R 777 ./dist
@@ -54,7 +54,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: github-pages
-          path: ./dist/sites/js.cubing.net/
+          path: ./dist/
           retention-days: 1
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -35,7 +35,7 @@ jobs:
       - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
       - run: find dist -type l -ls
       - run: rm -rf dist/**/.nojekyll
-      - run: chown -R root ./dist/
+      - run: sudo chown -R root ./dist/
       - run: find dist -type l -ls
       - name: Upload artifact
         uses: actions/upload-artifact@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,10 +6,6 @@ jobs:
   build-and-deploy-pages:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [18.x]
-
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     # https://github.com/actions/deploy-pages#usage
     permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,12 +3,24 @@ name: GitHub Pages
 on: [push]
 
 jobs:
-  build-pages:
+  build-and-deploy-pages:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         node-version: [18.x]
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    # https://github.com/actions/deploy-pages#usage
+    permissions:
+      contents: read
+      pages: write      # to deploy to Pages
+      deployments: write
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - uses: actions/checkout@v2
@@ -44,23 +56,6 @@ jobs:
           name: github-pages
           path: ./dist/sites/js.cubing.net/
           retention-days: 1
-
-  deploy-pages:
-    runs-on: ubuntu-latest
-    needs: build-pages
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
-    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
-    # https://github.com/actions/deploy-pages#usage
-    permissions:
-      contents: read
-      pages: write      # to deploy to Pages
-      deployments: write
-      id-token: write   # to verify the deployment originates from an appropriate source
-
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,10 +30,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: make build-site-docs
+      - run: mkdir -p ./dist/sites/js.cubing.net/
+      - run: echo "js.cubing.net" > ./dist/sites/js.cubing.net/CNAME
+      - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
       - run: find dist -type l -ls
       - run: rm -rf dist/**/.nojekyll
-      - run: sudo chown -R root ./dist/
+      - run: chown -R root ./dist/
       - run: find dist -type l -ls
       - name: Upload artifact
         uses: actions/upload-artifact@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: mkdir -p ./dist/sites/js.cubing.net/
       - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
+      - run: ls -al ./dist/sites/js.cubing.net/index.html
       - name: Upload artifact
         uses: actions/upload-artifact@main
         with:
@@ -44,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,7 +39,7 @@ jobs:
       - run: sudo chown -R root ./dist/
       - run: find dist -type l -ls
       - name: Upload artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v3
         with:
           name: github-pages
           path: ./dist/sites/js.cubing.net/

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,8 @@ jobs:
       - run: mkdir -p ./dist/sites/js.cubing.net/
       - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
       - run: ls -al ./dist/sites/js.cubing.net/index.html
+      - run: chown -R root ./dist/sites/js.cubing.net/
+      - run: ls -al ./dist/sites/js.cubing.net/index.html
       - name: Upload artifact
         uses: actions/upload-artifact@main
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,11 +49,9 @@ jobs:
       - run: sudo chown -R root ./dist/
       - run: find dist -type l -ls
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-pages-artifact@v1
         with:
-          name: github-pages
-          path: ./dist/sites/js.cubing.net/
-          retention-days: 1
+          path: './dist/sites/js.cubing.net'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,10 +30,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: mkdir -p ./dist/sites/js.cubing.net/
-      - run: echo "hi!" > ./dist/sites/js.cubing.net/index.html
+      - run: make build-site-docs
       - run: find dist -type l -ls
       - run: rm -rf dist/**/.nojekyll
+      - run: sudo chown -R root ./dist/
       - run: find dist -type l -ls
       - name: Upload artifact
         uses: actions/upload-artifact@main


### PR DESCRIPTION
This is the official Action for uploading Pages artifacts. It is a composite Action that basically [runs a `tar` command](https://github.com/actions/upload-pages-artifact/blob/a597aecd27af1cf14095ccaa29169358e3d91e28/action.yml#L16-L28) followed by [running the `actions/upload-artifact` Action](https://github.com/actions/upload-pages-artifact/blob/a597aecd27af1cf14095ccaa29169358e3d91e28/action.yml#L61-L66) you were already using.

P.S. You can also check out our example [Pages starter workflows](https://github.com/actions/starter-workflows/tree/main/pages), though keep in mind they have some template variables in them that need to be replaced if you attempt to copy them directly. They are also offered up in the GitHub UI based on your repository contents when you change your repository's Pages settings to build using Actions (in which case the template variables are replaced).