### PR TITLE
Include the `quantumMetric` option for `twsearch` calls.

### DIFF
--- a/src/cubing/search/inside/solve/twsearch.ts
+++ b/src/cubing/search/inside/solve/twsearch.ts
@@ -16,6 +16,7 @@ export interface TwsearchOptions {
   targetPattern?: KTransformationData;
   minDepth?: number;
   maxDepth?: number;
+  quantumMetric?: boolean;
 }
 
 export async function wasmTwsearch(

--- a/src/cubing/search/outside.ts
+++ b/src/cubing/search/outside.ts
@@ -6,9 +6,9 @@ import type { PrefetchLevel } from "./inside/api";
 import { randomClockScrambleString } from "./inside/solve/puzzles/clock"; // TODO: don't reach into `inside` code.
 import type { TwsearchOptions } from "./inside/solve/twsearch";
 import {
-  type InsideOutsideAPI,
   instantiateWorker,
   mapToAllWorkers,
+  type InsideOutsideAPI,
 } from "./instantiator";
 
 let cachedWorkerInstance: Promise<InsideOutsideAPI> | undefined;
@@ -119,6 +119,7 @@ export interface SolveTwsearchOptions {
   generatorMoves?: string[];
   startPattern?: KPattern;
   minDepth?: number;
+  quantumMetric?: boolean;
 }
 
 export async function solveTwsearch(

--- a/src/cubing/vendor/mpl/twsearch/index.js
+++ b/src/cubing/vendor/mpl/twsearch/index.js
@@ -460,7 +460,7 @@ var twsearch_wasm_default = __wbg_init;
 var cachedInitWrapper;
 async function initWrapper() {
   await (cachedInitWrapper ??= (async () => {
-    const wasmUint8Array = (await import("./twsearch_wasm_bg-BXMNNHLU.js")).default;
+    const wasmUint8Array = (await import("./twsearch_wasm_bg-FNRELPF3.js")).default;
     await twsearch_wasm_default(wasmUint8Array.buffer);
   })());
 }

--- a/src/cubing/vendor/mpl/twsearch/twsearch_wasm_bg-BXMNNHLU.js
+++ b/src/cubing/vendor/mpl/twsearch/twsearch_wasm_bg-BXMNNHLU.js
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:36086e89253da656644c0fb89be8640164b15898b687113cbb2913a96de28809
-size 413927

--- a/src/cubing/vendor/mpl/twsearch/twsearch_wasm_bg-FNRELPF3.js
+++ b/src/cubing/vendor/mpl/twsearch/twsearch_wasm_bg-FNRELPF3.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9679ab33a09edbe89d10dc73efcceda9344bdb7fa851add5ca02f4111e7ddb53
+size 414275

--- a/src/sites/experiments.cubing.net/cubing.js/stub/stub.ts
+++ b/src/sites/experiments.cubing.net/cubing.js/stub/stub.ts
@@ -1,2 +1,17 @@
 // Stub file for testing.
 // Feel free to add code here if you need a quick place to run some code, but avoid committing any changes.
+
+import { cube2x2x2 } from "cubing/puzzles";
+import { experimentalSolveTwsearch } from "cubing/search";
+
+const kpuzzle = await cube2x2x2.kpuzzle();
+const pattern = kpuzzle.defaultPattern().applyAlg("L2 F' U' F L2 F2");
+
+console.log(
+  (
+    await experimentalSolveTwsearch(kpuzzle, pattern, {
+      generatorMoves: ["U", "F", "R"],
+      quantumMetric: true,
+    })
+  ).toString(),
+);


### PR DESCRIPTION
This doesn't work yet.