### PR TITLE
Added event listeners to TwistyPlayer

### DIFF
--- a/src/cubing/twisty/views/TwistyPlayer.ts
+++ b/src/cubing/twisty/views/TwistyPlayer.ts
@@ -16,14 +16,14 @@ import type { SetupToLocation } from "../model/props/puzzle/state/SetupAnchorPro
 import type { PuzzleID } from "../model/props/puzzle/structure/PuzzleIDRequestProp";
 import type { BackgroundThemeWithAuto } from "../model/props/viewer/BackgroundProp";
 import type { BackViewLayoutWithAuto } from "../model/props/viewer/BackViewProp";
-import {
-  type ControlPanelThemeWithAuto,
-  controlsLocations,
-} from "../model/props/viewer/ControlPanelProp";
 import type {
   ColorScheme,
   ColorSchemeWithAuto,
 } from "../model/props/viewer/ColorSchemeRequestProp";
+import {
+  type ControlPanelThemeWithAuto,
+  controlsLocations,
+} from "../model/props/viewer/ControlPanelProp";
 import type { ViewerLinkPageWithAuto } from "../model/props/viewer/ViewerLinkProp";
 import type { VisualizationFormatWithAuto } from "../model/props/viewer/VisualizationProp";
 import type { VisualizationStrategy } from "../model/props/viewer/VisualizationStrategyProp";
@@ -536,18 +536,17 @@ export class TwistyPlayer
   private addEventListeners(): void {
     // Using mousedown/mouseup & touchstart/touchend to detect clicks, since click event would always trigger on mouseup.
     // Bind native DOM events to internal handlers
-    this.#visualizationWrapperElem.addEventListener(
-      "mousedown",
-      (event) => this.handleMouseDown(event)
+    this.#visualizationWrapperElem.addEventListener("mousedown", (event) =>
+      this.handleMouseDown(event),
     );
-    this.#visualizationWrapperElem.addEventListener(
-      "mouseup", (event) => this.handleMouseUp(event)
+    this.#visualizationWrapperElem.addEventListener("mouseup", (event) =>
+      this.handleMouseUp(event),
     );
-    this.#visualizationWrapperElem.addEventListener(
-      "touchstart", (event) => this.handleTouchStart(event)
+    this.#visualizationWrapperElem.addEventListener("touchstart", (event) =>
+      this.handleTouchStart(event),
     );
-    this.#visualizationWrapperElem.addEventListener("touchend",
-      (event) => this.handleTouchEnd(event)
+    this.#visualizationWrapperElem.addEventListener("touchend", (event) =>
+      this.handleTouchEnd(event),
     );
   }
 
@@ -555,7 +554,7 @@ export class TwistyPlayer
     // Call the onMouseDown callback if it exists, passing the event as an argument.
     this.onMouseDown?.(event);
 
-     // Save the mousedown point.
+    // Save the mousedown point.
     this.clickCoordinatesStart = { x: event.clientX, y: event.clientY };
   }
 
@@ -563,11 +562,11 @@ export class TwistyPlayer
     // Call the onMouseUp callback if it exists, passing the event as an argument.
     this.onMouseUp?.(event);
 
-     // Check if mousedown & mouseup are on the same point.
+    // Check if mousedown & mouseup are on the same point.
     if (
       this.isSamePoint(this.clickCoordinatesStart, {
         x: event.clientX,
-        y: event.clientY
+        y: event.clientY,
       })
     ) {
       // Call the onClick callback if it exists, passing the event as an argument.
@@ -593,7 +592,7 @@ export class TwistyPlayer
     if (
       this.isSamePoint(this.clickCoordinatesStart, {
         x: touch.clientX,
-        y: touch.clientY
+        y: touch.clientY,
       })
     ) {
       // Call the onClick callback if it exists, passing the event as an argument.

--- a/src/cubing/twisty/views/TwistyPlayer.ts
+++ b/src/cubing/twisty/views/TwistyPlayer.ts
@@ -536,10 +536,19 @@ export class TwistyPlayer
   private addEventListeners(): void {
     // Using mousedown/mouseup & touchstart/touchend to detect clicks, since click event would always trigger on mouseup.
     // Bind native DOM events to internal handlers
-    this.#visualizationWrapperElem.addEventListener("mousedown", (event) => this.handleMouseDown(event));
-    this.#visualizationWrapperElem.addEventListener("mouseup", (event) => this.handleMouseUp(event));
-    this.#visualizationWrapperElem.addEventListener("touchstart", (event) => this.handleTouchStart(event));
-    this.#visualizationWrapperElem.addEventListener("touchend", (event) => this.handleTouchEnd(event));
+    this.#visualizationWrapperElem.addEventListener(
+      "mousedown",
+      (event) => this.handleMouseDown(event)
+    );
+    this.#visualizationWrapperElem.addEventListener(
+      "mouseup", (event) => this.handleMouseUp(event)
+    );
+    this.#visualizationWrapperElem.addEventListener(
+      "touchstart", (event) => this.handleTouchStart(event)
+    );
+    this.#visualizationWrapperElem.addEventListener("touchend",
+      (event) => this.handleTouchEnd(event)
+    );
   }
 
   private handleMouseDown(event: MouseEvent): void {
@@ -555,7 +564,12 @@ export class TwistyPlayer
     this.onMouseUp?.(event);
 
      // Check if mousedown & mouseup are on the same point.
-    if (this.isSamePoint(this.clickCoordinatesStart, { x: event.clientX, y: event.clientY })) {
+    if (
+      this.isSamePoint(this.clickCoordinatesStart, {
+        x: event.clientX,
+        y: event.clientY
+      })
+    ) {
       // Call the onClick callback if it exists, passing the event as an argument.
       this.onClick?.(event);
     }
@@ -576,7 +590,12 @@ export class TwistyPlayer
 
     // Check if touchstart & touchend are on the same point.
     const touch = event.changedTouches[0];
-    if (this.isSamePoint(this.clickCoordinatesStart, { x: touch.clientX, y: touch.clientY })) {
+    if (
+      this.isSamePoint(this.clickCoordinatesStart, {
+        x: touch.clientX,
+        y: touch.clientY
+      })
+    ) {
       // Call the onClick callback if it exists, passing the event as an argument.
       this.onClick?.(event);
     }


### PR DESCRIPTION
Added event listeners that trigger when the user interacts with visualizationWrapperElem of TwistyPlayer. 
- canvas-mousedown
- canvas-mouseup
- canvas-touchstart
- canvas-touchend
- canvas-click

I implemented the click event for Feature Request #344.
Unfortunately, attaching a click event listener to visualizationWrapperElem would also trigger the event when the mouse is released at a different point than where it was pressed. Therefore, I added all these event listeners to check if the click and release point is the same to trigger the custom click event.

This is my `stub.ts` for testing:
```
import { TwistyPlayer } from "cubing/twisty";
const twistyPlayer = document.body.appendChild(new TwistyPlayer());
twistyPlayer.addEventListener("canvas-click", (e: MouseEvent) => { console.log("Click", e); });
twistyPlayer.addEventListener("canvas-mousedown" , (e: MouseEvent) => { console.log("Mousedown", e); });
twistyPlayer.addEventListener("canvas-mouseup", (e: MouseEvent) => { console.log("Mouseup", e); });
twistyPlayer.addEventListener("canvas-touchstart", (e: TouchEvent) => { console.log("Touchstart", e); });
twistyPlayer.addEventListener("canvas-touchend", (e: TouchEvent) => { console.log("Touchend", e); });
```

During testing, I encountered an issue with the Inspection tool in Google Chrome. While simulating a handheld device, clicking with the mouse (same press and release point) triggers touch and mouse events. This results in triggering the `canvas-click` event twice. This might be an issue for developers implementing TwistyPlayer. Should this be tackled?
In Firefox, simulation a handheld device only triggers mouse events.


Are the names of the events okay like that or is there a better idea?

Please tell me if the code is unclear or can be written in a better way.
