### PR TITLE
Revert "[puzzle-geometry] Hotfix for z-fighting in Chrome."

### DIFF
--- a/src/cubing/twisty/views/3D/puzzles/PG3D.ts
+++ b/src/cubing/twisty/views/3D/puzzles/PG3D.ts
@@ -274,7 +274,7 @@ class StickerDef {
   private foundationCoords(coords: number[]): number[] {
     const ncoords = coords.slice();
     for (let i = 0; i < coords.length; i++) {
-      ncoords[i] = coords[i] * 0.995;
+      ncoords[i] = coords[i] * 0.999;
     }
     return ncoords;
   }


### PR DESCRIPTION
This reverts commit 239431a0b5aa9f4e4ab3804b6ca90f0d6662ef4a.

Addresses https://github.com/cubing/cubing.js/issues/355