### PR TITLE
[bluetooth] Fix QiYi connection on Android

### DIFF
--- a/src/cubing/bluetooth/smart-puzzle/qiyi.ts
+++ b/src/cubing/bluetooth/smart-puzzle/qiyi.ts
@@ -248,8 +248,7 @@ export class QiyiCube extends BluetoothPuzzle {
     private server: BluetoothRemoteGATTServer,
   ) {
     super();
-    this.sendAppHello();
-    this.startNotifications();
+    this.startNotifications().then(this.sendAppHello.bind(this));
     this.allTimeStamps = new Set();
     this.allTimeStampsQueue = [];
   }


### PR DESCRIPTION
On Android (with Chrome), the current implementation doesn't connect to the cube because there is a race condition between sending the first message to the cube, and starting notifications. This fixes that issue by waiting to send "App Hello" until after starting notifications.

This is the same issue and solution as this pull request by [afedotov](https://github.com/afedotov) in the cstimer repository: [https://github.com/cs0x7f/cstimer/pull/404](https://github.com/cs0x7f/cstimer/pull/404)

I tested that these changes resolve this issue with the following commands and then accessing the server using Chrome's remote android debugging feature:

```sh
make build
cd dist
python3 -m "http.server"
```