### PR TITLE
[bluetooth] Add optional MAC retrieval function

### DIFF
--- a/src/cubing/bluetooth/connect/index.ts
+++ b/src/cubing/bluetooth/connect/index.ts
@@ -1,4 +1,5 @@
 import { debugLog } from "../debug";
+import { getMacAddressProvider, type MacAddressProviderOption } from "../mac";
 import type { BluetoothConfig } from "../smart-puzzle/bluetooth-puzzle";
 
 /******** requestOptions ********/
@@ -30,12 +31,9 @@ function requestOptions<T>(
 
 /******** connect() ********/
 
-/** Type representing a custom MAC address provider for smart cubes */
-export type MacAddressProvider = () => Promise<string>;
-
 export interface BluetoothConnectOptions {
   acceptAllDevices?: boolean;
-  macAddressProvider?: MacAddressProvider;
+  macAddressProvider?: MacAddressProviderOption;
 }
 
 // We globally track the number of connection failures,
@@ -90,41 +88,11 @@ export async function bluetoothConnect<T>(
         return config.connect({
           server,
           device,
-          macAddressProvider: addMacAddressValidation(
-            options.macAddressProvider || defaultMacAddressProvider,
-          ),
+          macAddressProvider: getMacAddressProvider(options.macAddressProvider),
         });
       }
     }
   }
 
   throw Error("Unknown Bluetooth device.");
-}
-
-const MAC_ADDRESS_REGEX = /^[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}$/;
-async function defaultMacAddressProvider(): Promise<string> {
-  while (true) {
-    const address = prompt("Enter your cube's MAC address:")?.trim();
-    if (!address) {
-      continue;
-    }
-    const isValidMacAddress = MAC_ADDRESS_REGEX.test(address);
-    if (isValidMacAddress) {
-      return address;
-    }
-  }
-}
-
-function addMacAddressValidation(
-  macAddressProvider: MacAddressProvider,
-): MacAddressProvider {
-  return async () => {
-    const providedMacAddress = await macAddressProvider();
-    const isValidMacAddress = MAC_ADDRESS_REGEX.test(providedMacAddress);
-    if (isValidMacAddress) {
-      return providedMacAddress;
-    } else {
-      throw Error(`Invalid MAC address: ${providedMacAddress}`);
-    }
-  };
 }

--- a/src/cubing/bluetooth/mac.ts
+++ b/src/cubing/bluetooth/mac.ts
@@ -1,0 +1,142 @@
+/**
+ * Type of MAC address provider to use when a bluetooth device's MAC address
+ * is needed and cannot automatically be determined, and as a fallback when
+ * automatically determining the MAC address fails.
+ *
+ * - `"PROMPT"`: Use the built-in prompt-based provider (default).
+ * - `"DIALOG"`: Use the built-in dialog-based provider.
+ * - {@link MacAddressProvider}: Use a custom MAC address provider.
+ */
+export type MacAddressProviderOption =
+  | "PROMPT"
+  | "DIALOG"
+  | MacAddressProvider
+  | undefined;
+
+/** Type representing a custom MAC address provider for bluetooth devices */
+export type MacAddressProvider = () => Promise<string>;
+
+/**
+ * An error that should be thrown by a {@link MacAddressProvider} to
+ * signal that the user cancelled entering a MAC address.
+ */
+export class MacAddressCancelledError extends Error {}
+
+/**
+ * Converts a {@link MacAddressProviderOption} to a {@link MacAddressProvider},
+ * using `"PROMPT"` as the default option.
+ * @param macAddressProviderOption {@link MacAddressProviderOption} provided by the user.
+ * @returns final MAC address provider that can be called by bluetooth device configs
+ */
+export function getMacAddressProvider(
+  macAddressProviderOption: MacAddressProviderOption,
+): MacAddressProvider {
+  macAddressProviderOption ||= "PROMPT";
+
+  let provider: MacAddressProvider;
+  switch (macAddressProviderOption) {
+    case "DIALOG":
+      provider = dialogMacAddressProvider;
+      break;
+
+    case "PROMPT":
+      provider = promptMacAddressProvider;
+      break;
+
+    default:
+      provider = macAddressProviderOption;
+      break;
+  }
+
+  return async () => {
+    const macAddress = (await provider()).trim();
+    validateMacAddress(macAddress);
+    return macAddress;
+  };
+}
+
+const MAC_ADDRESS_REGEX = /^[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}$/;
+
+/**
+ * Validates the MAC address returned by a {@link MacAddressProvider}.
+ * @param macAddress MAC address returned by a {@link MacAddressProvider}
+ * @throws error if the MAC address is invalid
+ */
+function validateMacAddress(macAddress: string) {
+  if (!MAC_ADDRESS_REGEX.test(macAddress)) {
+    throw new Error(`Invalid MAC address: ${macAddress}`);
+  }
+}
+
+/**
+ * Default prompt-based MAC address provider
+ * @returns Bluetooth device MAC address
+ */
+export async function promptMacAddressProvider(): Promise<string> {
+  while (true) {
+    const address = prompt(
+      "Enter your bluetooth device's MAC address:",
+    )?.trim();
+    if (address === undefined) {
+      // User cancelled prompt
+      throw new MacAddressCancelledError();
+    }
+    const isValidMacAddress = MAC_ADDRESS_REGEX.test(address);
+    if (isValidMacAddress) {
+      return address;
+    }
+  }
+}
+
+/**
+ * Default dialog-based MAC address provider
+ * @returns Bluetooth device MAC address
+ */
+export function dialogMacAddressProvider(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    // TODO: Replace with a cleaner web component implementation
+    const dialog = document.createElement("dialog");
+
+    // TODO: Add custom CSS styles
+    dialog.innerHTML = `
+      <h2>Enter your bluetooth device's MAC address</h2>
+      <form>
+        <input type="text" placeholder="MAC Address">
+        <p style="color: red;"></p>
+        <button type="submit">Submit</button>
+      </form>
+    `;
+
+    document.querySelector("body")!.appendChild(dialog);
+    const feedback = dialog.querySelector("p")!;
+    const macInput = dialog.querySelector("input")!;
+
+    const button = dialog.querySelector("button")!;
+
+    const validateInput = () => {
+      if (!MAC_ADDRESS_REGEX.test(macInput.value)) {
+        feedback.textContent = "Invalid MAC address.";
+        button.disabled = true;
+      } else {
+        feedback.textContent = "";
+        button.disabled = false;
+      }
+    };
+
+    macInput.addEventListener("keyup", validateInput);
+    validateInput();
+
+    dialog.querySelector("form")!.addEventListener("submit", (e) => {
+      e.preventDefault();
+      document.querySelector("body")!.removeChild(dialog);
+      resolve(macInput.value);
+    });
+
+    // TODO: clean up error handling
+    dialog.addEventListener("close", () =>
+      reject(new MacAddressCancelledError()),
+    );
+
+    dialog.showModal();
+  });
+}

--- a/src/cubing/bluetooth/smart-puzzle/Heykube.ts
+++ b/src/cubing/bluetooth/smart-puzzle/Heykube.ts
@@ -9,7 +9,11 @@ import {
 } from "../../protocol";
 import { puzzles } from "../../puzzles";
 import { debugLog } from "../debug";
-import { type BluetoothConfig, BluetoothPuzzle } from "./bluetooth-puzzle";
+import {
+  type BluetoothConfig,
+  BluetoothPuzzle,
+  type ConnectionArguments,
+} from "./bluetooth-puzzle";
 import { flipBitOrder } from "./endianness";
 
 // TODO: Short IDs
@@ -22,10 +26,10 @@ const UUIDs = {
 /** @category Smart Puzzles */
 export class HeykubeCube extends BluetoothPuzzle {
   // We have to perform async operations before we call the constructor.
-  public static async connect(
-    server: BluetoothRemoteGATTServer,
-    device: BluetoothDevice,
-  ): Promise<HeykubeCube> {
+  public static async connect({
+    server,
+    device,
+  }: ConnectionArguments): Promise<HeykubeCube> {
     const service = await server.getPrimaryService(UUIDs.heykubeService);
     debugLog("Service:", service);
 

--- a/src/cubing/bluetooth/smart-puzzle/bluetooth-puzzle.ts
+++ b/src/cubing/bluetooth/smart-puzzle/bluetooth-puzzle.ts
@@ -1,6 +1,6 @@
 import type { AlgLeaf } from "../../alg/alg-nodes/AlgNode";
 import type { KPattern } from "../../kpuzzle/KPattern";
-import type { MacAddressProvider } from "../connect";
+import type { MacAddressProvider } from "../mac";
 import {
   BasicRotationTransformer,
   type StreamTransformer,
@@ -32,7 +32,6 @@ export interface OrientationEvent {
   debug?: Record<string, unknown>;
 }
 
-/** Type representing the arguments passed to smart cube connection functions. */
 export type ConnectionArguments = {
   server: BluetoothRemoteGATTServer;
   device: BluetoothDevice;

--- a/src/cubing/bluetooth/smart-puzzle/bluetooth-puzzle.ts
+++ b/src/cubing/bluetooth/smart-puzzle/bluetooth-puzzle.ts
@@ -1,5 +1,6 @@
 import type { AlgLeaf } from "../../alg/alg-nodes/AlgNode";
 import type { KPattern } from "../../kpuzzle/KPattern";
+import type { MacAddressProvider } from "../connect";
 import {
   BasicRotationTransformer,
   type StreamTransformer,
@@ -31,16 +32,15 @@ export interface OrientationEvent {
   debug?: Record<string, unknown>;
 }
 
+/** Type representing the arguments passed to smart cube connection functions. */
+export type ConnectionArguments = {
+  server: BluetoothRemoteGATTServer;
+  device: BluetoothDevice;
+  macAddressProvider: MacAddressProvider;
+};
+
 export interface BluetoothConfig<T> {
-  connect:
-    | ((
-        server: BluetoothRemoteGATTServer,
-        device: BluetoothDevice,
-      ) => Promise<T>)
-    | ((
-        server: BluetoothRemoteGATTServer,
-        device?: BluetoothDevice,
-      ) => Promise<T>);
+  connect: (connectionArguments: ConnectionArguments) => Promise<T>;
   // TODO: Can we reuse `filters`?
   prefixes: string[]; // `[""]` for GiiKER
   filters: BluetoothLEScanFilter[];

--- a/src/cubing/bluetooth/smart-puzzle/gan.ts
+++ b/src/cubing/bluetooth/smart-puzzle/gan.ts
@@ -9,7 +9,11 @@ import {
   unsafeDecryptBlock,
 } from "../../vendor/public-domain/unsafe-raw-aes/unsafe-raw-aes";
 import { debugLog } from "../debug";
-import { type BluetoothConfig, BluetoothPuzzle } from "./bluetooth-puzzle";
+import {
+  type BluetoothConfig,
+  BluetoothPuzzle,
+  type ConnectionArguments,
+} from "./bluetooth-puzzle";
 import { getPatternData } from "./common";
 
 // This needs to be short enough to capture 6 moves (OBQTM).
@@ -238,9 +242,9 @@ async function getKey(
 /** @category Smart Puzzles */
 export class GanCube extends BluetoothPuzzle {
   // We have to perform async operations before we call the constructor.
-  public static async connect(
-    server: BluetoothRemoteGATTServer,
-  ): Promise<GanCube> {
+  public static async connect({
+    server,
+  }: ConnectionArguments): Promise<GanCube> {
     const ganCubeService = await server.getPrimaryService(UUIDs.ganCubeService);
     debugLog("Service:", ganCubeService);
 

--- a/src/cubing/bluetooth/smart-puzzle/giiker.ts
+++ b/src/cubing/bluetooth/smart-puzzle/giiker.ts
@@ -4,7 +4,11 @@ import { Move } from "../../alg";
 import { KPattern, type KPatternData } from "../../kpuzzle";
 import { experimental3x3x3KPuzzle } from "../../puzzles/cubing-private";
 import { debugLog } from "../debug";
-import { type BluetoothConfig, BluetoothPuzzle } from "./bluetooth-puzzle";
+import {
+  type BluetoothConfig,
+  BluetoothPuzzle,
+  type ConnectionArguments,
+} from "./bluetooth-puzzle";
 
 const MESSAGE_LENGTH = 20;
 
@@ -112,9 +116,9 @@ async function decodeState(data: Uint8Array): Promise<Uint8Array> {
 
 /** @category Smart Puzzles */
 export class GiiKERCube extends BluetoothPuzzle {
-  public static async connect(
-    server: BluetoothRemoteGATTServer,
-  ): Promise<GiiKERCube> {
+  public static async connect({
+    server,
+  }: ConnectionArguments): Promise<GiiKERCube> {
     const cubeService = await server.getPrimaryService(UUIDs.cubeService);
     debugLog("Service:", cubeService);
 

--- a/src/cubing/bluetooth/smart-puzzle/gocube.ts
+++ b/src/cubing/bluetooth/smart-puzzle/gocube.ts
@@ -1,7 +1,11 @@
 import { Quaternion } from "three/src/math/Quaternion.js";
 import { Alg, experimentalAppendMove, Move } from "../../alg";
 import { debugLog } from "../debug";
-import { type BluetoothConfig, BluetoothPuzzle } from "./bluetooth-puzzle";
+import {
+  type BluetoothConfig,
+  BluetoothPuzzle,
+  type ConnectionArguments,
+} from "./bluetooth-puzzle";
 
 const UUIDs = {
   goCubeService: "6e400001-b5a3-f393-e0a9-e50e24dcca9e",
@@ -45,9 +49,9 @@ const moveMap: Move[] = [
 /** @category Smart Puzzles */
 export class GoCube extends BluetoothPuzzle {
   // We have to perform async operations before we call the constructor.
-  public static async connect(
-    server: BluetoothRemoteGATTServer,
-  ): Promise<GoCube> {
+  public static async connect({
+    server,
+  }: ConnectionArguments): Promise<GoCube> {
     const service = await server.getPrimaryService(UUIDs.goCubeService);
     debugLog({ service });
     const goCubeStateCharacteristic = await service.getCharacteristic(

--- a/src/cubing/bluetooth/smart-puzzle/qiyi.ts
+++ b/src/cubing/bluetooth/smart-puzzle/qiyi.ts
@@ -8,7 +8,11 @@ import {
   unsafeDecryptBlock,
   unsafeEncryptBlock,
 } from "../../vendor/public-domain/unsafe-raw-aes/unsafe-raw-aes";
-import { type BluetoothConfig, BluetoothPuzzle } from "./bluetooth-puzzle";
+import {
+  type BluetoothConfig,
+  BluetoothPuzzle,
+  type ConnectionArguments,
+} from "./bluetooth-puzzle";
 import { getPatternData } from "./common";
 
 const UUIDs = {
@@ -230,9 +234,9 @@ export class QiyiCube extends BluetoothPuzzle {
   ];
   private batteryLevel: number = 100;
 
-  public static async connect(
-    server: BluetoothRemoteGATTServer,
-  ): Promise<BluetoothPuzzle> {
+  public static async connect({
+    server,
+  }: ConnectionArguments): Promise<BluetoothPuzzle> {
     const aesKey = await importKey(
       new Uint8Array([
         87, 177, 249, 171, 205, 90, 232, 167, 156, 185, 140, 231, 87, 140, 81,

--- a/src/cubing/bluetooth/smart-robot/GanRobot.ts
+++ b/src/cubing/bluetooth/smart-robot/GanRobot.ts
@@ -1,6 +1,9 @@
 import { Alg, Move as AlgNode, Move } from "../../alg";
 import { cube3x3x3 } from "../../puzzles";
-import type { BluetoothConfig } from "../smart-puzzle/bluetooth-puzzle";
+import type {
+  BluetoothConfig,
+  ConnectionArguments as BluetoothConnectionArguments,
+} from "../smart-puzzle/bluetooth-puzzle";
 
 // TODO: Remove this. It's only used for debugging.
 function buf2hex(buffer: ArrayBuffer | Uint8Array): string {
@@ -132,10 +135,7 @@ export class GanRobot extends EventTarget {
   }
 
   // We have to perform async operations before we call the constructor.
-  static async connect(
-    server: BluetoothRemoteGATTServer,
-    device: BluetoothDevice,
-  ) {
+  static async connect({ server, device }: BluetoothConnectionArguments) {
     const ganTimerService = await server.getPrimaryService(
       UUIDs.ganRobotService,
     );

--- a/src/cubing/bluetooth/smart-timer/GanTimer.ts
+++ b/src/cubing/bluetooth/smart-timer/GanTimer.ts
@@ -1,5 +1,8 @@
 import type { MillisecondTimestamp } from "../../twisty/controllers/AnimationTypes";
-import type { BluetoothConfig } from "../smart-puzzle/bluetooth-puzzle";
+import type {
+  BluetoothConfig,
+  ConnectionArguments,
+} from "../smart-puzzle/bluetooth-puzzle";
 
 // TODO: Short IDs
 const UUIDs = {
@@ -37,10 +40,7 @@ export class GanTimer extends EventTarget {
   }
 
   // We have to perform async operations before we call the constructor.
-  static async connect(
-    server: BluetoothRemoteGATTServer,
-    device: BluetoothDevice,
-  ) {
+  static async connect({ server, device }: ConnectionArguments) {
     const ganTimerService = await server.getPrimaryService(
       UUIDs.ganTimerService,
     );


### PR DESCRIPTION
To work with some Bluetooth smart cubes, it is required to know the cube's MAC address, which is not accessible through Web Bluetooth. For example, each of the GAN Gen2 smart cubes use the cube's MAC address to salt the encryption key and IV. While it is possible to get this through `watchAdvertisements()`, which [gan-web-bluetooth](https://github.com/afedotov/gan-web-bluetooth/blob/65173e2cdd0fa38ef384f237f6da8d76c177ed1e/src/gan-smart-cube.ts#L43) and [cstimer](https://github.com/cs0x7f/cstimer/blob/e8e04eb2859f9284c04e0d233f2ce6e141cad142/src/js/hardware/bluetooth.js#L40) do, this doesn't work on all platforms ([Linux and ChromeOS are not supported, and it requires enabling 'enable-experimental-web-platform-features' in Chrome flags](https://github.com/WebBluetoothCG/web-bluetooth/blob/main/implementation-status.md#scanning-api)). Both gan-web-bluetooth and cstimer have prompts to use if `watchAdvertisements()` doesn't work.

I was not sure how to implement something like this for cubing.js, but I took a stab at it in a way that I think aligns with some of the goals of the project. So, I added a parameter that is passed to each cube's connect function, so that cube configs that need the MAC address of the cube (and can't find it automatically) may choose to request it.

To prevent breaking any existing code, and to make it more simple for someone to get running, there is a default MAC address provider, which uses the browser's `prompt()` function, and some basic regex validation. I thought it would also be good to let developers give their own MAC address providers (i.e. to match their existing interfaces), so I added that as an option to `BluetoothConnectOptions`, and I wrapped the call to the MAC address provider with a function that throws an error if the string returned by the MAC address provider is invalid.

I tested that this code using `make test-all`, by manually confirming that the QiYi cube I have still functions correctly, and I verified that `make build` successfully builds the project.

I am not super confident with how I implemented the default MAC address provider, and I wasn't sure where to put some of the types (like `ConnectionArguments`and `MacAddressProvider`). Also, more generally, I would love to hear other ideas to solve this issue (maybe there's a better solution than passing a provider) or how I could make this change fit the goals of the project more!