### PR TITLE
[DO NOT MERGE] Test with `deno`.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -104,6 +104,8 @@ jobs:
       - run: make build-lib-js
       - run: make test-dist-lib-node-import
       - run: make test-dist-lib-node-scramble
+      - run: make test-dist-lib-deno-import
+      - run: make test-dist-lib-deno-scramble
       - run: make test-dist-lib-bun-scramble-all-events
       - run: make test-dist-lib-perf
       - run: make test-dist-lib-plain-esbuild-compat

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BUN_DX=${BUN} x -- bun-dx
 BUN_RUN=${BUN} run --
 BIOME=${BUN_DX} --package @biomejs/biome biome --
 NODE=node --
+DENO=bun x -- bun-dx --package deno deno --
 NPM=npm
 WEB_TEST_RUNNER=${BUN_DX} --package @web/test-runner web-test-runner -- # TODO(https://github.com/oven-sh/bun/issues/9178): restore this to @web/test-runner
 
@@ -171,6 +172,8 @@ test-dist: test-dist-lib test-dist-bin
 test-dist-lib: \
 	test-dist-lib-node-import \
 	test-dist-lib-node-scramble \
+	test-dist-lib-deno-import \
+	test-dist-lib-deno-scramble \
 	test-dist-lib-bun-scramble-all-events \
 	test-dist-lib-perf \
 	test-dist-lib-plain-esbuild-compat \
@@ -184,6 +187,14 @@ test-dist-lib-node-import: build-lib-js
 .PHONY: test-dist-lib-node-scramble
 test-dist-lib-node-scramble: build-lib-js
 	${NODE} script/test/dist/lib/cubing/node/scramble/main.js
+
+.PHONY: test-dist-lib-deno-import
+test-dist-lib-deno-import: build-lib-js
+	${DENO} --allow-read --allow-sys --allow-env -- script/test/dist/lib/cubing/node/import/main.js
+
+.PHONY: test-dist-lib-deno-scramble
+test-dist-lib-deno-scramble: build-lib-js
+	${DENO} --allow-read --allow-sys --allow-env -- script/test/dist/lib/cubing/node/scramble/main.js
 
 .PHONY: test-dist-lib-bun-scramble-all-events
 test-dist-lib-bun-scramble-all-events: build-lib-js

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "barely-a-dev-server": "v0.8.0",
         "bun-dx": ">=0.1.3",
         "chai": "^5.1.1",
+        "deno": "^2.6.5",
         "esbuild": "^0.25.0",
         "jszip": "^3.10.1",
         "mocha": "^10.7.3",
@@ -74,6 +75,18 @@
     "@cubing/deploy": ["@cubing/deploy@0.4.10", "", { "dependencies": { "path-class": ">=0.10.3", "printable-shell-command": ">=2.6.3" }, "bin": { "deploy": "dist/cli/main.js" } }, "sha512-IQ13vLUpMvIU/cZxw0wDnwoUpwEpiZDNDTlaaUV/mfUnOxzbyZi/TrIucar400oPTq/rC1/9qWrKCIxxTbXIAg=="],
 
     "@cubing/dev-config": ["@cubing/dev-config@0.9.1", "", { "dependencies": { "esbuild": ">=0.25.3 && <1.0.0", "path-class": ">=0.10.8", "printable-shell-command": ">=4.0.3" }, "bin": { "package.json": "bin/package.json/index.js" } }, "sha512-y2caPnI4estkb17+9WNKYwv2lfEs5nMixFJ+ZpxH4DSr0/WC027BHCVtni1Bdv6nJ+DLKAMpMyK0SNBb/mC+bA=="],
+
+    "@deno/darwin-arm64": ["@deno/darwin-arm64@2.6.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jHO9d9XsB2YzVUsJr7U9DEj7QEw69yMYbyaLbK1bpHJ6IjYRJFU/Wi7I1b9jSXurezQQulKf75+9QbU27XkL2g=="],
+
+    "@deno/darwin-x64": ["@deno/darwin-x64@2.6.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-piyZbW02p4zlviz14UVvoUGhh2mu0OYQBBahdLIbnHaPC14Rj+fHu0vgG8+PTJNCIRkxA1zrm5/GBbjqU3GeZQ=="],
+
+    "@deno/linux-arm64-glibc": ["@deno/linux-arm64-glibc@2.6.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-9VjtjIepMgSc6aHNOvjHAlHkG/Lmatoeb6k5vpCtVLpwJWJcteIrNX+Rc2u7HcfJctfPs6HwDYsCGI/jnwwzGw=="],
+
+    "@deno/linux-x64-glibc": ["@deno/linux-x64-glibc@2.6.5", "", { "os": "linux", "cpu": "x64" }, "sha512-TZV2Ez3T1qaA7snLKvevwq2LyTGI+1lCQrULZgrytmcaa0Q/9aErA3c135CSscv5LDKSWUXtBCWOHHI6rGm9MA=="],
+
+    "@deno/win32-arm64": ["@deno/win32-arm64@2.6.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-5zPTnSv0R72GwVxxP20cLN/K5VJd6mF5yaLd/4tnwpv4jExiiQWaoXrae/M8O16Ruz8R+AIpIJfs3oZ+2gwuzA=="],
+
+    "@deno/win32-x64": ["@deno/win32-x64@2.6.5", "", { "os": "win32", "cpu": "x64" }, "sha512-vSr5ZjBvv5n80Bwa9P0WVLpUNLqnDtXMFIuR7H4mdo5zXU9Ay8ggPQ83yPMjmgqRZOBJNXQDFUA3ZWW+UmMjYQ=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
@@ -512,6 +525,8 @@
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
 
     "delegates": ["delegates@1.0.0", "", {}, "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="],
+
+    "deno": ["deno@2.6.5", "", { "optionalDependencies": { "@deno/darwin-arm64": "2.6.5", "@deno/darwin-x64": "2.6.5", "@deno/linux-arm64-glibc": "2.6.5", "@deno/linux-x64-glibc": "2.6.5", "@deno/win32-arm64": "2.6.5", "@deno/win32-x64": "2.6.5" }, "bin": { "deno": "bin.cjs" } }, "sha512-zAEGhAKPyKTA7HwtSVPAmdpj+WQfvw0tPemgkaRsqGLe7oi85iqUPCoCEkItiYp3ZellfQIbDHqQmKUY6fgxig=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "barely-a-dev-server": "v0.8.0",
     "bun-dx": ">=0.1.3",
     "chai": "^5.1.1",
+    "deno": "^2.6.5",
     "esbuild": "^0.25.0",
     "jszip": "^3.10.1",
     "mocha": "^10.7.3",


### PR DESCRIPTION
Unfortunately, this results in two copies of a 92MB binary in `node_modues`, which I'm less than enthused about: https://github.com/cubing/cubing.js/issues/411